### PR TITLE
ci: add manual release workflow with binary packaging

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,29 +58,16 @@ jobs:
           name: ${{ steps.meta.outputs.name }}-${{ steps.meta.outputs.os }}-${{ steps.meta.outputs.arch }}
           path: dist/*.tar.gz
 
-      # 🧾 Generate release notes (SAFE VERSION)
+      # 🧾 Generate release notes (CUSTOM STRUCTURE)
       - name: Generate release notes
         run: |
-          echo "## ${{ steps.meta.outputs.name }} v${{ steps.meta.outputs.version }} 🚀" > release.md
+          echo "## BruteCraber v${{ steps.meta.outputs.version }} Latest" > release.md
           echo "" >> release.md
-          echo "### 🖥️ Build Info" >> release.md
-          echo "- OS: ${{ steps.meta.outputs.os }}" >> release.md
-          echo "- Architecture: ${{ steps.meta.outputs.arch }}" >> release.md
-          echo "- Rust Toolchain: stable" >> release.md
+          echo "### What's New in v${{ steps.meta.outputs.version }}" >> release.md
           echo "" >> release.md
-          echo "### ✨ What's Included" >> release.md
-          echo "- Automated release via GitHub Actions" >> release.md
-          echo "- Built using cargo build --release" >> release.md
-          echo "- Optimized binary for performance" >> release.md
-          echo "" >> release.md
-          echo "### 📦 Download" >> release.md
-          echo "${{ steps.meta.outputs.name }}-${{ steps.meta.outputs.os }}-${{ steps.meta.outputs.arch }}.tar.gz" >> release.md
-          echo "" >> release.md
-          echo "### 🔐 Notes" >> release.md
-          echo "- Version sourced from Cargo.toml" >> release.md
-          echo "- Reproducible build with --locked" >> release.md
+          echo "_(Maintainers can update this section manually with detailed changes.)_" >> release.md
 
-      # 🚀 Create Release
+     # 🚀 Create Release
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary
Adds a manual GitHub Actions workflow to build and publish Linux release binaries.

## Features
- Manual trigger (workflow_dispatch)
- Builds project using cargo build --release
- Automatically extracts version from Cargo.toml
- Packages binary into .tar.gz
- Creates GitHub Release with attached artifact
- Structured release notes (maintainer editable)

## Why
Automates release process and removes manual binary packaging.

## Related Issue
Closes #24