### PR TITLE
feat: enable GPU backend by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "A blazing-fast, multithreaded hash cracker built with Rust"
 repository = "https://github.com/Erikgavs/brutecraber"
 
 [features]
-default = []
+default = ["gpu"]
 gpu = ["opencl3"]
 
 [dependencies]

--- a/src/gpu_backend.rs
+++ b/src/gpu_backend.rs
@@ -20,9 +20,13 @@ const SHA3_256_KERNEL_SOURCE: &str = include_str!("kernels/sha3_256.cl");
 const SHA3_512_KERNEL_SOURCE: &str = include_str!("kernels/sha3_512.cl");
 const NTLM_KERNEL_SOURCE: &str = include_str!("kernels/ntlm.cl");
 
-const GPU_SUPPORTED_HEX_TYPES: &[&str] = &[
+pub const GPU_SUPPORTED_HEX_TYPES: &[&str] = &[
     "md5", "sha1", "sha256", "sha512", "sha3-256", "sha3-512", "ntlm",
 ];
+
+pub fn supports(hash_type: &str) -> bool {
+    GPU_SUPPORTED_HEX_TYPES.contains(&hash_type)
+}
 
 pub struct GpuBackend {
     device: Device,

--- a/src/gpu_backend.rs
+++ b/src/gpu_backend.rs
@@ -77,13 +77,12 @@ impl GpuBackend {
         let mem_mb = mem_bytes / (1024 * 1024);
 
         println!(
-            " {} GPU: {} | VRAM: {} MB | Compute Units: {}",
+            "{} GPU: {} | VRAM: {} MB | Compute Units: {}\n",
             "[*]".green(),
             name.trim().yellow(),
             mem_mb,
             cu
         );
-        println!();
     }
 
     fn gpu_mem_bytes(&self) -> u64 {

--- a/src/gpu_backend.rs
+++ b/src/gpu_backend.rs
@@ -49,11 +49,11 @@ impl GpuBackend {
 
         for &did in &device_ids {
             let dev = Device::new(did);
-            if let Ok(cu) = dev.max_compute_units() {
-                if cu > best_cu {
-                    best_cu = cu;
-                    best_id = did;
-                }
+            if let Ok(cu) = dev.max_compute_units()
+                && cu > best_cu
+            {
+                best_cu = cu;
+                best_id = did;
             }
         }
 
@@ -91,6 +91,7 @@ impl GpuBackend {
 
     /// Generic hash cracking method that works for any algorithm.
     /// All GPU-supported algorithms share the same kernel interface.
+    #[allow(clippy::too_many_arguments)]
     fn crack_hash(
         &self,
         hashes: &[&str],
@@ -251,6 +252,7 @@ impl GpuBackend {
     }
 
     /// Generic GPU batch execution — kernel interface is the same for all algorithms.
+    #[allow(clippy::too_many_arguments)]
     fn execute_hash_batch(
         &self,
         kernel: &Kernel,
@@ -475,7 +477,7 @@ impl CrackingBackend for GpuBackend {
             );
             expanded_wordlist = wordlist
                 .lines()
-                .flat_map(|word| crate::rules::apply(word))
+                .flat_map(crate::rules::apply)
                 .collect::<Vec<_>>()
                 .join("\n");
             expanded_wordlist.as_str()

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ fn main() -> anyhow::Result<()> {
             use crate::gpu_backend::{self, GpuBackend};
 
             if force_cpu {
-                println!(" {} --cpu flag set, using CPU", "[*]".yellow());
+                println!("{} --cpu flag set, using CPU \n", "[*]".yellow());
                 CpuBackend.run(&hashes, &wordlist, &auto_detect, args.rules)
             } else if !gpu_backend::supports(&auto_detect) {
                 println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,16 +102,7 @@ fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     if args.benchmark {
-        let use_gpu = {
-            #[cfg(feature = "gpu")]
-            {
-                args.gpu
-            }
-            #[cfg(not(feature = "gpu"))]
-            {
-                false
-            }
-        };
+        let use_gpu = cfg!(feature = "gpu");
         benchmark::run(use_gpu);
         return Ok(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,7 @@ fn main() -> anyhow::Result<()> {
         println!("{} Selected hash: {}\n", star, auto_detect.green());
     }
 
-    let force_cpu = std::env::var("BRUTECRABER_CPU").is_ok();
+    let force_cpu = args.cpu;
 
     let found = {
         #[cfg(feature = "gpu")]
@@ -156,7 +156,7 @@ fn main() -> anyhow::Result<()> {
             use crate::gpu_backend::{self, GpuBackend};
 
             if force_cpu {
-                println!(" {} BRUTECRABER_CPU set, using CPU", "[*]".yellow());
+                println!(" {} --cpu flag set, using CPU", "[*]".yellow());
                 CpuBackend.run(&hashes, &wordlist, &auto_detect, args.rules)
             } else if !gpu_backend::supports(&auto_detect) {
                 println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,9 @@ struct Args {
 
     #[arg(long = "benchmark", default_value_t = false)]
     benchmark: bool,
+
+    #[arg(long = "cpu", default_value_t = false, help = "Force CPU backend")]
+    cpu: bool,
 }
 
 fn banner() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,14 +43,6 @@ struct Args {
 
     #[arg(long = "benchmark", default_value_t = false)]
     benchmark: bool,
-
-    #[cfg(feature = "gpu")]
-    #[arg(
-        long = "gpu",
-        default_value_t = false,
-        help = "Use GPU acceleration (OpenCL)"
-    )]
-    gpu: bool,
 }
 
 fn banner() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,32 +145,46 @@ fn main() -> anyhow::Result<()> {
         println!("{} Selected hash: {}\n", star, auto_detect.green());
     }
 
-    #[cfg(feature = "gpu")]
-    if args.gpu {
-        use crate::gpu_backend::GpuBackend;
+    let force_cpu = std::env::var("BRUTECRABER_CPU").is_ok();
 
-        let gpu = match GpuBackend::new() {
-            Ok(g) => g,
-            Err(e) => {
-                eprintln!(" {} {}", "[!]".red(), e);
-                return Err(anyhow::anyhow!(e));
+    let found = {
+        #[cfg(feature = "gpu")]
+        {
+            use crate::gpu_backend::{self, GpuBackend};
+
+            if force_cpu {
+                println!(" {} BRUTECRABER_CPU set, using CPU", "[*]".yellow());
+                CpuBackend.run(&hashes, &wordlist, &auto_detect, args.rules)
+            } else if !gpu_backend::supports(&auto_detect) {
+                println!(
+                    " {} hash {} not supported on GPU, using CPU",
+                    "[*]".yellow(),
+                    auto_detect
+                );
+                CpuBackend.run(&hashes, &wordlist, &auto_detect, args.rules)
+            } else {
+                match GpuBackend::new() {
+                    Ok(gpu) => {
+                        gpu.print_device_info();
+                        gpu.run(&hashes, &wordlist, &auto_detect, args.rules)
+                    }
+                    Err(e) => {
+                        println!(
+                            " {} GPU unavailable ({}), falling back to CPU",
+                            "[!]".yellow(),
+                            e
+                        );
+                        CpuBackend.run(&hashes, &wordlist, &auto_detect, args.rules)
+                    }
+                }
             }
-        };
-        gpu.print_device_info();
-
-        let found = gpu.run(&hashes, &wordlist, &auto_detect, args.rules);
-
-        println!();
-        if found == 0 {
-            println!("{} failed cracking hashes or bad file\n", star.red());
-        } else {
-            println!("{} cracked {}/{} hashes", star.green(), found, hashes.len());
         }
-        return Ok(());
-    }
-
-    let backend = CpuBackend;
-    let found = backend.run(&hashes, &wordlist, &auto_detect, args.rules);
+        #[cfg(not(feature = "gpu"))]
+        {
+            let _ = force_cpu;
+            CpuBackend.run(&hashes, &wordlist, &auto_detect, args.rules)
+        }
+    };
 
     println!();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,7 @@ fn main() -> anyhow::Result<()> {
                 CpuBackend.run(&hashes, &wordlist, &auto_detect, args.rules)
             } else if !gpu_backend::supports(&auto_detect) {
                 println!(
-                    " {} hash {} not supported on GPU, using CPU",
+                    "{} hash {} not supported on GPU, using CPU",
                     "[*]".yellow(),
                     auto_detect
                 );
@@ -173,7 +173,7 @@ fn main() -> anyhow::Result<()> {
                     }
                     Err(e) => {
                         println!(
-                            " {} GPU unavailable ({}), falling back to CPU",
+                            "{} GPU unavailable ({}), falling back to CPU",
                             "[!]".yellow(),
                             e
                         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,11 +156,11 @@ fn main() -> anyhow::Result<()> {
             use crate::gpu_backend::{self, GpuBackend};
 
             if force_cpu {
-                println!("{} --cpu flag set, using CPU \n", "[*]".yellow());
+                println!("{} --cpu flag set, using CPU\n", "[*]".yellow());
                 CpuBackend.run(&hashes, &wordlist, &auto_detect, args.rules)
             } else if !gpu_backend::supports(&auto_detect) {
                 println!(
-                    "{} hash {} not supported on GPU, using CPU",
+                    "{} hash {} not supported on GPU, using CPU\n",
                     "[*]".yellow(),
                     auto_detect
                 );
@@ -173,7 +173,7 @@ fn main() -> anyhow::Result<()> {
                     }
                     Err(e) => {
                         println!(
-                            "{} GPU unavailable ({}), falling back to CPU",
+                            "{} GPU unavailable ({}), falling back to CPU\n",
                             "[!]".yellow(),
                             e
                         );


### PR DESCRIPTION
## Summary
  - Enables the `gpu` feature by default in `Cargo.toml` so the official binary ships with OpenCL support out of the box, no `--features gpu`
   required at build time.
  - Users who want a GPU-less binary can still build with `--no-default-features`.

  ## Motivation
  First step toward a "GPU by default with CPU fallback" flow. The end goal is that the user doesn't have to pick a backend: GPU is used when
   available, CPU otherwise.

  ## Notes
  - Requires OpenCL to be installed on the host (ships with GPU drivers in most cases).
  - Automatic runtime fallback logic will land in a follow-up PR.

  ## Test plan
  - [x] `cargo build` compiles with no extra flags.
  - [x] `cargo build --no-default-features` still compiles (CPU-only mode).
  - [ ] `cargo test` passes.
  - [ ] Run a basic MD5 crack to confirm GPU path still works as before.