### PR TITLE
Feature/thread flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,9 @@ struct Args {
 
     #[arg(long = "detect-hash", help = "Detect hash type in your hash file")]
     detect_hash: Option<String>,
+
+    #[arg(short = 'j', help = "Number of threads used in cracking")]
+    jobs: Option<usize>,
 }
 
 fn banner() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,13 @@ fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
 
+    if let Some(n) = args.jobs {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(n)
+            .build_global()
+            .ok();
+    }
+
     if args.benchmark {
         let use_gpu = cfg!(feature = "gpu");
         benchmark::run(use_gpu);


### PR DESCRIPTION
## Summary

  Adds `-j N` flag to control how many threads rayon uses for cracking. If omitted, all cores are used (same behaviour as before).

  ## Usage

  ```bash
  brutecraber -f hashes.txt -w wordlist.txt -j 4

  Notes

  - rayon::ThreadPoolBuilder::build_global() is called once at startup before any parallel work.
  - Backwards compatible: existing commands work without changes.